### PR TITLE
allow usage of any element/selector for the chart, instead of just ap…

### DIFF
--- a/gantt-chart-d3.js
+++ b/gantt-chart-d3.js
@@ -118,7 +118,7 @@ d3.gantt = function() {
 	initTimeDomain(tasks);
 	initAxis();
 	
-        var svg = d3.select("svg");
+        var svg = d3.select(".chart");
 
         var ganttChartGroup = svg.select(".gantt-chart");
         var rect = ganttChartGroup.selectAll("rect").data(tasks, keyFunction);

--- a/gantt-chart-d3.js
+++ b/gantt-chart-d3.js
@@ -118,7 +118,7 @@ d3.gantt = function() {
 	initTimeDomain(tasks);
 	initAxis();
 	
-        var svg = d3.select(".chart");
+        var svg = d3.select("svg");
 
         var ganttChartGroup = svg.select(".gantt-chart");
         var rect = ganttChartGroup.selectAll("rect").data(tasks, keyFunction);

--- a/gantt-chart-d3.js
+++ b/gantt-chart-d3.js
@@ -13,6 +13,7 @@ d3.gantt = function() {
 	bottom : 20,
 	left : 150
     };
+    var selector = 'body';
     var timeDomainStart = d3.time.day.offset(new Date(),-3);
     var timeDomainEnd = d3.time.hour.offset(new Date(),+3);
     var timeDomainMode = FIT_TIME_DOMAIN_MODE;// fixed or fit
@@ -72,7 +73,7 @@ d3.gantt = function() {
 	initTimeDomain(tasks);
 	initAxis();
 	
-	var svg = d3.select("body")
+	var svg = d3.select(selector)
 	.append("svg")
 	.attr("class", "chart")
 	.attr("width", width + margin.left + margin.right)
@@ -215,7 +216,12 @@ d3.gantt = function() {
 	return gantt;
     };
 
+    gantt.selector = function(value) {
+	if (!arguments.length)
+	    return selector;
+	selector = value;
+	return gantt;
+    };
 
-    
     return gantt;
 };


### PR DESCRIPTION
Out of the box the graph is always appended to body element (d3.select("body")), however I needed to display the graph inside the page in a specific div.

This pull request makes it possible to specify the element. By default everything still works as before, but to use custom element add selector() method call like this

```
 var gantt = d3.gantt().taskTypes(taskNames).taskStatus(taskStatus).tickFormat(format).selector('#chart').height(450).width(800);
```