### PR TITLE
FIXED: redraw failed with more than 1 svg element on page

### DIFF
--- a/gantt-chart-d3.js
+++ b/gantt-chart-d3.js
@@ -117,7 +117,7 @@ d3.gantt = function() {
 	initTimeDomain(tasks);
 	initAxis();
 	
-        var svg = d3.select("svg");
+        var svg = d3.select(".chart");
 
         var ganttChartGroup = svg.select(".gantt-chart");
         var rect = ganttChartGroup.selectAll("rect").data(tasks, keyFunction);


### PR DESCRIPTION
Initial creation of gantt chart appends svg element to the body of document.

Subsequent calls to redraw will look for it with d3.select('svg') - which will
select the wrong element if there are other svg elements on the page

As a workaround select the graph using "chart" class name