### PR TITLE
Ensure minmal width of 1px for task bars

### DIFF
--- a/gantt-chart-d3.js
+++ b/gantt-chart-d3.js
@@ -97,7 +97,7 @@ d3.gantt = function() {
 	 .attr("transform", rectTransform)
 	 .attr("height", function(d) { return y.rangeBand(); })
 	 .attr("width", function(d) { 
-	     return (x(d.endDate) - x(d.startDate)); 
+	     return Math.max(1,(x(d.endDate) - x(d.startDate))); 
 	     });
 	 
 	 
@@ -136,14 +136,14 @@ d3.gantt = function() {
 	 .attr("transform", rectTransform)
 	 .attr("height", function(d) { return y.rangeBand(); })
 	 .attr("width", function(d) { 
-	     return (x(d.endDate) - x(d.startDate)); 
+	     return Math.max(1,(x(d.endDate) - x(d.startDate))); 
 	     });
 
         rect.transition()
           .attr("transform", rectTransform)
 	 .attr("height", function(d) { return y.rangeBand(); })
 	 .attr("width", function(d) { 
-	     return (x(d.endDate) - x(d.startDate)); 
+	     return Math.max(1,(x(d.endDate) - x(d.startDate))); 
 	     });
         
 	rect.exit().remove();


### PR DESCRIPTION
When visualizing the processes of an strace with this library it occurred that all task bars had a width of zero pixels. This patch avoids bars with zero width - all bars will have a minimum width of 1 pixel.