### PR TITLE
add ability to set number of xAxis ticks

### DIFF
--- a/gantt-chart-d3.js
+++ b/gantt-chart-d3.js
@@ -23,6 +23,9 @@ d3.gantt = function() {
     var width = document.body.clientWidth - margin.right - margin.left-5;
 
     var tickFormat = "%H:%M";
+    var ticksCount = 10;
+    var ticksInterval = null;
+    var ticksIntervalCount = null;
 
     var keyFunction = function(d) {
 	return d.startDate + d.taskName + d.endDate;
@@ -64,6 +67,11 @@ d3.gantt = function() {
 	y = d3.scale.ordinal().domain(taskTypes).rangeRoundBands([ 0, height - margin.top - margin.bottom ], .1);
 	xAxis = d3.svg.axis().scale(x).orient("bottom").tickFormat(d3.time.format(tickFormat)).tickSubdivide(true)
 		.tickSize(8).tickPadding(8);
+	if (ticksInterval !== null && ticksIntervalCount !== null) {
+		xAxis.ticks(ticksInterval, ticksIntervalCount);
+	} else {
+		xAxis.ticks(ticksCount);
+	}
 
 	yAxis = d3.svg.axis().scale(y).orient("left").tickSize(0);
     };
@@ -214,6 +222,20 @@ d3.gantt = function() {
 	    return tickFormat;
 	tickFormat = value;
 	return gantt;
+    };
+
+    gantt.ticks = function(...args) {
+    if (!arguments.length)
+    	return ticksCount;
+   	if (arguments.length == 1) {
+   		ticksInterval = null;
+   		ticksIntervalCount = null;
+   		ticksCount = arguments[0];
+   	} else {
+	   	ticksInterval = arguments[0];
+	   	ticksIntervalCount = arguments[1];
+	}
+   	return gantt;
     };
 
     gantt.selector = function(value) {


### PR DESCRIPTION
Like `gantt.tickFormat()`, this change wraps [`d3.svg.axis.ticks()`](https://github.com/d3/d3-3.x-api-reference/blob/master/SVG-Axes.md#ticks) so that the user can set the ticks they want to see on the x axis.

- a single integer will approximate that number of ticks, e.g. `d3.gantt()....ticks(12)` will place approximately 12 ticks (the default behavior of `d3.svg.axis` is `.ticks(10)`).
- or, a [`d3.time interval`](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Intervals.md) can be used, e.g., `d3.gantt()....ticks(d3.time.month, 6)` will place a tick for every six months.
- calling `gantt().ticks()` with no arguments will return the current ticks setting.

`.ticks()` is an optional call, so, as with `d3.svg.axis`, this change should not effect existing implementations that do not use `.ticks()`.
